### PR TITLE
chore/collenchyma: bump collenchyma to 0.0.8

### DIFF
--- a/cudnn/Cargo.toml
+++ b/cudnn/Cargo.toml
@@ -15,7 +15,7 @@ license         = "MIT OR Apache-2.0"
 
 [dependencies]
 libc = "0.2"
-collenchyma = "0.0.7"
+collenchyma = "0.0.8"
 cudnn-sys = { version = "0.0.2", path = "../cudnn-sys" }
 
 clippy = { version = "0.0.27", optional = true }


### PR DESCRIPTION
Required so we can release [collenchyma-nn](https://github.com/autumnai/collenchyma-nn) with the same version of collenchyma.

Will also be necessary in future releases until https://github.com/autumnai/collenchyma/issues/4 is fixed.
