### PR TITLE
refactor/collenchyma: removed Collenchyma CUDA memory

### DIFF
--- a/cudnn/Cargo.toml
+++ b/cudnn/Cargo.toml
@@ -15,7 +15,6 @@ license         = "MIT OR Apache-2.0"
 
 [dependencies]
 libc = "0.2"
-collenchyma = "0.0.8"
 cudnn-sys = { version = "0.0.2", path = "../cudnn-sys" }
 
 clippy = { version = "0.0.27", optional = true }

--- a/cudnn/src/lib.rs
+++ b/cudnn/src/lib.rs
@@ -66,7 +66,6 @@
 
 extern crate libc;
 extern crate cudnn_sys as ffi;
-extern crate collenchyma as co;
 
 pub use ffi::*;
 pub use self::cudnn::Cudnn;


### PR DESCRIPTION
removed Collenchyma CUDA memory from ConvolutionConfig

CLOSES #16

BREAKING CHANGE: removes the workspace from the ConvolutionConfig,
changing its constructor and now requires an additional pointer to
be passed to convolution functions
