### PR TITLE
Make `ScalParams` a proper generic struct.

### DIFF
--- a/cudnn/Cargo.toml
+++ b/cudnn/Cargo.toml
@@ -16,6 +16,7 @@ license         = "MIT OR Apache-2.0"
 [dependencies]
 libc = "0.2"
 cudnn-sys = { version = "0.0.3", path = "../cudnn-sys" }
+num = "0.1.31"
 
 clippy = { version = "0.0.27", optional = true }
 

--- a/cudnn/src/cudnn.rs
+++ b/cudnn/src/cudnn.rs
@@ -5,7 +5,10 @@
 //! stores the handle and manages future calls.
 
 use super::*;
-use super::utils::{ConvolutionConfig, NormalizationConfig, PoolingConfig, ScalParams};
+use super::utils::{ConvolutionConfig, DataTypeInfo,
+                   NormalizationConfig, PoolingConfig, ScalParams};
+use num::traits::Float;
+use std::mem::transmute_copy;
 
 #[derive(Debug, Clone)]
 /// Provides a the high-level interface to CUDA's cuDNN.
@@ -109,12 +112,14 @@ impl Cudnn {
         dest_desc: &TensorDescriptor,
         dest_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::activation_forward(
             *self.id_c(),
             cudnnActivationMode_t::CUDNN_ACTIVATION_SIGMOID,
-            scale.a, *src_desc.id_c(), src_data,
-            scale.b, *dest_desc.id_c(), dest_data
+            unsafe { transmute_copy(&&scale.a) }, *src_desc.id_c(), src_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_desc.id_c(), dest_data
         )
     }
 
@@ -132,12 +137,16 @@ impl Cudnn {
         dest_diff_desc: &TensorDescriptor,
         dest_diff_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::activation_backward(
             *self.id_c(),
             cudnnActivationMode_t::CUDNN_ACTIVATION_SIGMOID,
-            scale.a, *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
-            scale.b, *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
+            unsafe { transmute_copy(&&scale.a) },
+            *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
+            unsafe { transmute_copy(&&scale.b) },
+            *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
         )
     }
 
@@ -151,12 +160,14 @@ impl Cudnn {
         dest_desc: &TensorDescriptor,
         dest_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::activation_forward(
             *self.id_c(),
             cudnnActivationMode_t::CUDNN_ACTIVATION_RELU,
-            scale.a, *src_desc.id_c(), src_data,
-            scale.b, *dest_desc.id_c(), dest_data
+            unsafe { transmute_copy(&&scale.a) }, *src_desc.id_c(), src_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_desc.id_c(), dest_data
         )
     }
 
@@ -174,12 +185,16 @@ impl Cudnn {
         dest_diff_desc: &TensorDescriptor,
         dest_diff_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::activation_backward(
             *self.id_c(),
             cudnnActivationMode_t::CUDNN_ACTIVATION_RELU,
-            scale.a, *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
-            scale.b, *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
+            unsafe { transmute_copy(&&scale.a) },
+            *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
+            unsafe { transmute_copy(&&scale.b) },
+            *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
         )
     }
 
@@ -193,12 +208,14 @@ impl Cudnn {
         dest_desc: &TensorDescriptor,
         dest_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::activation_forward(
             *self.id_c(),
             cudnnActivationMode_t::CUDNN_ACTIVATION_TANH,
-            scale.a, *src_desc.id_c(), src_data,
-            scale.b, *dest_desc.id_c(), dest_data
+            unsafe { transmute_copy(&&scale.a) }, *src_desc.id_c(), src_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_desc.id_c(), dest_data
         )
     }
 
@@ -216,12 +233,16 @@ impl Cudnn {
         dest_diff_desc: &TensorDescriptor,
         dest_diff_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::activation_backward(
             *self.id_c(),
             cudnnActivationMode_t::CUDNN_ACTIVATION_TANH,
-            scale.a, *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
-            scale.b, *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
+            unsafe { transmute_copy(&&scale.a) },
+            *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
+            unsafe { transmute_copy(&&scale.b) },
+            *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
         )
     }
 
@@ -238,12 +259,15 @@ impl Cudnn {
         dest_desc: &TensorDescriptor,
         dest_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::convolution_forward(
             *self.id_c(),
             *conv_config.forward_algo(), *conv_config.conv_desc().id_c(), workspace, *conv_config.forward_workspace_size(),
-            scale.a, *src_desc.id_c(), src_data, *conv_config.filter_desc().id_c(), filter_data,
-            scale.b, *dest_desc.id_c(), dest_data
+            unsafe { transmute_copy(&&scale.a) },
+            *src_desc.id_c(), src_data, *conv_config.filter_desc().id_c(), filter_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_desc.id_c(), dest_data
         )
     }
 
@@ -257,11 +281,14 @@ impl Cudnn {
         bias_grad_desc: &TensorDescriptor,
         bias_grad_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::convolution_backward_bias(
             *self.id_c(),
-            scale.a, *dest_grad_desc.id_c(), dest_grad_data,
-            scale.b, *bias_grad_desc.id_c(), bias_grad_data
+            unsafe { transmute_copy(&&scale.a) },
+            *dest_grad_desc.id_c(), dest_grad_data,
+            unsafe { transmute_copy(&&scale.b) }, *bias_grad_desc.id_c(), bias_grad_data
         )
     }
 
@@ -278,12 +305,15 @@ impl Cudnn {
         dest_grad_data: *const ::libc::c_void,
         filter_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::convolution_backward_filter(
             *self.id_c(),
             *conv_config.backward_filter_algo(), *conv_config.conv_desc().id_c(), workspace, *conv_config.backward_filter_workspace_size(),
-            scale.a, *src_desc.id_c(), src_data, *dest_grad_desc.id_c(), dest_grad_data,
-            scale.b, *conv_config.filter_desc().id_c(), filter_data
+            unsafe { transmute_copy(&&scale.a) },
+            *src_desc.id_c(), src_data, *dest_grad_desc.id_c(), dest_grad_data,
+            unsafe { transmute_copy(&&scale.b) }, *conv_config.filter_desc().id_c(), filter_data
         )
     }
 
@@ -300,12 +330,15 @@ impl Cudnn {
         src_grad_desc: &TensorDescriptor,
         src_grad_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::convolution_backward_data(
             *self.id_c(),
             *conv_config.backward_data_algo(), *conv_config.conv_desc().id_c(), workspace, *conv_config.backward_data_workspace_size(),
-            scale.a, *conv_config.filter_desc().id_c(), filter_data, *dest_grad_desc.id_c(), dest_grad_data,
-            scale.b, *src_grad_desc.id_c(), src_grad_data
+            unsafe { transmute_copy(&&scale.a) },
+            *conv_config.filter_desc().id_c(), filter_data, *dest_grad_desc.id_c(), dest_grad_data,
+            unsafe { transmute_copy(&&scale.b) }, *src_grad_desc.id_c(), src_grad_data
         )
     }
 
@@ -319,11 +352,13 @@ impl Cudnn {
         dest_desc: &TensorDescriptor,
         dest_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::softmax_forward(
             *self.id_c(), cudnnSoftmaxAlgorithm_t::CUDNN_SOFTMAX_FAST, cudnnSoftmaxMode_t::CUDNN_SOFTMAX_MODE_INSTANCE,
-            scale.a, *src_desc.id_c(), src_data,
-            scale.b, *dest_desc.id_c(), dest_data
+            unsafe { transmute_copy(&&scale.a) }, *src_desc.id_c(), src_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_desc.id_c(), dest_data
         )
     }
 
@@ -339,11 +374,14 @@ impl Cudnn {
         dest_diff_desc: &TensorDescriptor,
         dest_diff_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::softmax_backward(
             *self.id_c(), cudnnSoftmaxAlgorithm_t::CUDNN_SOFTMAX_FAST, cudnnSoftmaxMode_t::CUDNN_SOFTMAX_MODE_INSTANCE,
-            scale.a, *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
-            scale.b, *dest_diff_desc.id_c(), dest_diff_data
+            unsafe { transmute_copy(&&scale.a) },
+            *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_diff_desc.id_c(), dest_diff_data
         )
     }
 
@@ -357,11 +395,13 @@ impl Cudnn {
         dest_desc: &TensorDescriptor,
         dest_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::softmax_forward(
             *self.id_c(), cudnnSoftmaxAlgorithm_t::CUDNN_SOFTMAX_LOG, cudnnSoftmaxMode_t::CUDNN_SOFTMAX_MODE_INSTANCE,
-            scale.a, *src_desc.id_c(), src_data,
-            scale.b, *dest_desc.id_c(), dest_data
+            unsafe { transmute_copy(&&scale.a) }, *src_desc.id_c(), src_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_desc.id_c(), dest_data
         )
     }
 
@@ -377,11 +417,14 @@ impl Cudnn {
         dest_diff_desc: &TensorDescriptor,
         dest_diff_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::softmax_backward(
             *self.id_c(), cudnnSoftmaxAlgorithm_t::CUDNN_SOFTMAX_LOG, cudnnSoftmaxMode_t::CUDNN_SOFTMAX_MODE_INSTANCE,
-            scale.a, *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
-            scale.b, *dest_diff_desc.id_c(), dest_diff_data
+            unsafe { transmute_copy(&&scale.a) },
+            *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_diff_desc.id_c(), dest_diff_data
         )
     }
 
@@ -396,11 +439,13 @@ impl Cudnn {
         dest_desc: &TensorDescriptor,
         dest_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::lrn_cross_channel_forward(
             *self.id_c(), *normalization_conf.lrn_desc().id_c(), CUDNN_LRN_CROSS_CHANNEL_DIM1,
-            scale.a, *src_desc.id_c(), src_data,
-            scale.b, *dest_desc.id_c(), dest_data
+            unsafe { transmute_copy(&&scale.a) }, *src_desc.id_c(), src_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_desc.id_c(), dest_data
         )
     }
 
@@ -419,11 +464,15 @@ impl Cudnn {
         dest_diff_desc: &TensorDescriptor,
         dest_diff_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::lrn_cross_channel_backward(
             *self.id_c(), *normalization_conf.lrn_desc().id_c(), CUDNN_LRN_CROSS_CHANNEL_DIM1,
-            scale.a, *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
-            scale.b, *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
+            unsafe { transmute_copy(&&scale.a) },
+            *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
+            unsafe { transmute_copy(&&scale.b) },
+            *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
         )
     }
 
@@ -438,11 +487,13 @@ impl Cudnn {
         dest_desc: &TensorDescriptor,
         dest_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::pooling_forward(
             *self.id_c(), *pooling_conf.pooling_avg_desc().id_c(),
-            scale.a, *src_desc.id_c(), src_data,
-            scale.b, *dest_desc.id_c(), dest_data
+            unsafe { transmute_copy(&&scale.a) }, *src_desc.id_c(), src_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_desc.id_c(), dest_data
         )
     }
 
@@ -461,11 +512,15 @@ impl Cudnn {
         dest_diff_desc: &TensorDescriptor,
         dest_diff_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::pooling_backward(
             *self.id_c(), *pooling_conf.pooling_avg_desc().id_c(),
-            scale.a, *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
-            scale.b, *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
+            unsafe { transmute_copy(&&scale.a) },
+            *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
+            unsafe { transmute_copy(&&scale.b) },
+            *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
         )
     }
 
@@ -480,11 +535,13 @@ impl Cudnn {
         dest_desc: &TensorDescriptor,
         dest_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::pooling_forward(
             *self.id_c(), *pooling_conf.pooling_max_desc().id_c(),
-            scale.a, *src_desc.id_c(), src_data,
-            scale.b, *dest_desc.id_c(), dest_data
+            unsafe { transmute_copy(&&scale.a) }, *src_desc.id_c(), src_data,
+            unsafe { transmute_copy(&&scale.b) }, *dest_desc.id_c(), dest_data
         )
     }
 
@@ -503,11 +560,15 @@ impl Cudnn {
         dest_diff_desc: &TensorDescriptor,
         dest_diff_data: *mut ::libc::c_void,
         scale: ScalParams<T>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+        where T: Float + DataTypeInfo,
+    {
         API::pooling_backward(
             *self.id_c(), *pooling_conf.pooling_max_desc().id_c(),
-            scale.a, *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
-            scale.b, *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
+            unsafe { transmute_copy(&&scale.a) },
+            *src_desc.id_c(), src_data, *src_diff_desc.id_c(), src_diff_data,
+            unsafe { transmute_copy(&&scale.b) },
+            *dest_desc.id_c(), dest_data, *dest_diff_desc.id_c(), dest_diff_data
         )
     }
 }

--- a/cudnn/src/lib.rs
+++ b/cudnn/src/lib.rs
@@ -66,6 +66,7 @@
 
 extern crate libc;
 extern crate cudnn_sys as ffi;
+extern crate num;
 
 pub use ffi::*;
 pub use self::cudnn::Cudnn;


### PR DESCRIPTION
So downstream crates can also be generic.
